### PR TITLE
fix: pypi release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,14 @@ classifiers =
     Programming Language :: Python :: 3.7
 
 [options]
-packages =
-    bigsmiles
+setup_requires =
+    setuptools
 package_dir =
     =src
+packages = find_namespace:
 python_requires = >=3.7
 zip_safe = no
 include_package_data = true
+
+[options.packages.find]
+where = src


### PR DESCRIPTION
Attempt to fix #7, but not 100% confident it will work (I cant debug this, you have to do it @dylanwal).

The problem in #7 is that only the top-level code (`.py` files) are copied into the pypi-installed package and the subdirectories are not copied. You have to tell setuptools where and how to look for subdirectories