### PR TITLE
Text tokenizer

### DIFF
--- a/src/bigsmiles/constructors/tokenizer.py
+++ b/src/bigsmiles/constructors/tokenizer.py
@@ -138,7 +138,7 @@ class Token:
 def tokenize(text: str) -> list[Token]:
     """
 
-    tokenizes a bigSMILES string
+    tokenizes a bigSMILES string into a list of `Token` objects.
 
     Parameters
     ----------
@@ -186,6 +186,33 @@ def tokenize(text: str) -> list[Token]:
 
     return result
 
+def tokenize_text(text: str) -> list[str]:
+    """
+
+    tokenizes a bigSMILES string into a list of strings
+
+    Parameters
+    ----------
+    text: str
+        BigSMILES string
+
+    Returns
+    -------
+    result: list[str]
+        A list of strings, one for each token
+
+    Raises
+    ------
+    TokenizeError
+        invalid symbol detected
+
+    Examples
+    --------
+    >>> tokenize("CC{[>][<]CC(C)[>][<]}CC(C)=C")
+    """
+    tokens = tokenize(text)
+    tokenized_text = [t.value for t in tokens]
+    return tokenized_text
 
 ATOM_PATTERN = re.compile(atom_pattern)
 

--- a/src/bigsmiles/constructors/tokenizer.py
+++ b/src/bigsmiles/constructors/tokenizer.py
@@ -210,9 +210,27 @@ def tokenize_text(text: str) -> list[str]:
     --------
     >>> tokenize("CC{[>][<]CC(C)[>][<]}CC(C)=C")
     """
-    tokens = tokenize(text)
-    tokenized_text = [t.value for t in tokens]
-    return tokenized_text
+    result = []
+    for match in re.finditer(tok_regex, text.replace(" ", "")):
+        kind = match.lastgroup
+
+        value = match.group()
+        if kind == 'SKIP':
+            continue
+        elif kind == 'MISMATCH':
+            if text[:2] in chemical_data.element_symbols:
+                raise TokenizeError(f"Invalid symbol. If the symbol is not in the list below it must be in []."
+                                    f"\nNon-bracket elements: {chemical_data.organic_elements}"
+                                    f"\n(starting with {value!r}; index: {match.span()[0]})"
+                                f'\n{text}' + "\n" + " " * match.span()[0] + "^(and forward)")
+
+            raise TokenizeError(f'Invalid symbol (or group of symbols). (starting with {value!r}; '
+                                f'index: {match.span()[0]})'
+                                f'\n{text}' + "\n" + " " * match.span()[0] + "^(and forward)")
+
+        result.append(value)
+
+    return result
 
 ATOM_PATTERN = re.compile(atom_pattern)
 


### PR DESCRIPTION
I wanted support for pure text-based tokenization, meaning that I can enter a BigSMILES string and return a list of strings, each containing a token of the full BigSMILES. This will be useful/critical for chemical language models on top of BigSMILES.

I added a function to support this. I first wrapped it around the existing `tokenize` method (see #[6d58f06](https://github.com/dylanwal/BigSMILES/commit/6d58f062259c83c0874e11c919aa873641d4198f))  but then realized this will be slower than duplicating the code and simply skipping the creation of the `Token` and `TokenKind` objects (see #[d0afaf1](https://github.com/dylanwal/BigSMILES/commit/d0afaf1f448279cba9bdaaffe7ff5f4e311bd1cf))
